### PR TITLE
Update Capital Whiterun Expansion - SurWR.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26560,23 +26560,13 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/63355/'
         name: 'Rob''s Bug Fixes - Capital Whiterun Expansion'
     msg:
-      - <<: *patchIncluded
-        subs: [ 'Creation Club - Fishing' ]
-        condition: 'active("ccBGSSSE001-Fish.esm") and not active("SurWR - Fishing.esp") and checksum("SurWR.esp", C1861BE4)'
       - <<: *patchUpdateAvailable
         subs: [ '[Rob''s Bug Fixes - Capital Whiterun Expansion](https://www.nexusmods.com/skyrimspecialedition/mods/63355/)' ]
         condition: 'checksum("SurWR.esp", D96CF5BF)'
     clean:
       - crc: 0xD96CF5BF
         util: 'SSEEdit v4.0.4b'
-      - crc: 0xC1861BE4
-        util: 'SSEEdit v4.0.4b'
-  - name: 'SurWR - Fishing.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/63355/'
-        name: 'Rob''s Bug Fixes - Capital Whiterun Expansion'
-    clean:
-      - crc: 0xA7A3B1AB
+      - crc: 0x87CC3785
         util: 'SSEEdit v4.0.4b'
 
   - name: 'JKs Skyrim - Rob''s Bug Fixes.esp'


### PR DESCRIPTION
Updated metadata for my Bug Fixes page, and removal of the fishing patch.  Re-reviewed the main plugin from scratch.  Recent 1.6.x update to the CC plugin removed the record that was conflicting, making the patch no longer needed.  Removed that patch from the mod paqe.